### PR TITLE
Ensure that we remove the old volume before we add the new one

### DIFF
--- a/lagotto/init.sls
+++ b/lagotto/init.sls
@@ -55,9 +55,9 @@ include:
     - require:
       - {{ app_name }}-app-container-absent
       - {{ app_name }}-web-container-absent
+    - require_in:
+      - docker_volume: {{ app_name }}-assets-volume
     - name: {{ app_name }}-railsassets
-    - onlyif:
-      - docker inspect {{ app_name }}-railsassets > /dev/null
 
 {{ app_name }}-assets-volume:
   docker_volume.present:


### PR DESCRIPTION
We were encountering errors in highstates where this docker_volume.absent state was incorrectly running after the state that was suppose to add it. It's suppose to run in the opposite order: to remove the volume and readd it.

The `only_if` was unnecessary. I previously incorrectly thought that the error was from docker trying to remove a volume that was already gone.