### PR TITLE
ALM-1080 configure subscribers

### DIFF
--- a/lagotto/conf/code/config/subscribers.yml
+++ b/lagotto/conf/code/config/subscribers.yml
@@ -1,0 +1,17 @@
+{% set environment = grains['environment'] %}
+---
+# A request will be made to the subscriber url
+# when a milestone has been passed for the specified source
+# and the article is for the specified journal
+#
+# :subscribers:
+# - :journal: pbio
+#   :source: crossref
+#   :milestones: [1, 15]
+#   :url: 'http://example.com'
+{%if environment == 'prod' %}
+:subscribers: []
+{% else %}
+:subscribers: []
+{% endif %}
+...

--- a/lagotto/init.sls
+++ b/lagotto/init.sls
@@ -40,12 +40,14 @@ include:
       - {{ app_port }}:{{ app_port }}
     - binds:
       - {{ app_name }}-railsassets:/code/public
+      - /code/config/subscribers.yml:/code/config/subscribers.yml
     - networks:
       - {{ app_name }}
     - require:
       - {{ app_name }}-image
       - {{ app_name }}-network
       - {{ app_name }}-assets-volume
+      - {{ app_name }}-subscribers-config-file
     - command: docker/start.sh {{ mysql_host }}:3306
 
 {{ app_name }}-assets-volume-absent:
@@ -62,6 +64,12 @@ include:
 {{ app_name }}-assets-volume:
   docker_volume.present:
     - name: {{ app_name }}-railsassets
+
+{{ app_name }}-subscribers-config-file:
+  file.managed:
+    - name: /code/config/subscribers.yml
+    - source: salt://lagotto/conf/code/config/subscribers.yml
+    - template: jinja
 
 {{ consul_service_definition("alm-manager-app", 
                              port=app_port, 


### PR DESCRIPTION
https://jira.plos.org/jira/browse/ALM-1080

The subscribers config is managed as a bind mount to a file on the host that is managed by salt.

See: https://github.com/PLOS/lagotto/pull/44
