### PR TITLE
ALM-1045 ensure cron jobs continue to exist

### DIFF
--- a/lagotto/conf/etc/cron.d/lagotto-worker
+++ b/lagotto/conf/etc/cron.d/lagotto-worker
@@ -1,0 +1,14 @@
+MAILTO=dev@plos.org
+SHELL=/bin/bash
+HOME=/home/root
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+5 * * * * root chronic docker exec {{ container_name }} rake cron:hourly
+
+20 1 * * * root chronic docker exec {{ container_name }} rake cron:daily
+
+40 1 * * 1 root chronic docker exec {{ container_name }} rake cron:weekly
+
+50 2 10 * * root chronic docker exec {{ container_name }} rake cron:monthly
+
+20 11,16 * * * root chronic docker exec {{ container_name }} FROM_PUB_DATE=`date --date="7 days ago" +%Y-%m-%d` bundle exec rake cron:import --silent 

--- a/lagotto/sidekiq.sls
+++ b/lagotto/sidekiq.sls
@@ -24,3 +24,10 @@ include:
     - require:
       - {{ app_name }}-image
     - command: bundle exec sidekiq
+
+/etc/cron.d/{{ app_name }}-worker:
+  file.managed:
+    - source: salt://lagotto/conf/etc/cron.d/{{ app_name }}-worker
+    - template: jinja
+    - defaults:
+      container_name: {{ app_name }}-worker


### PR DESCRIPTION
This PR adds the cron jobs to salt that Whenever would have created. Here's the old jobs: https://github.com/PLOS/lagotto/blob/5aa998b21367154939633fa693975a85df97e5c1/config/schedule.rb#L6

This PR addresses @fcabrales-plos comment here: https://jira.plos.org/jira/browse/ALM-1045?focusedCommentId=263250&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-263250

