### PR TITLE
ALM-1045 fix docker exec env var

### DIFF
--- a/lagotto/conf/etc/cron.d/lagotto-worker
+++ b/lagotto/conf/etc/cron.d/lagotto-worker
@@ -11,4 +11,4 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 50 2 10 * * root chronic docker exec {{ container_name }} rake cron:monthly
 
-20 11,16 * * * root chronic docker exec {{ container_name }} FROM_PUB_DATE=`date --date="7 days ago" +%Y-%m-%d` bundle exec rake cron:import --silent 
+20 11,16 * * * root chronic docker exec -e FROM_PUB_DATE=`date --date="7 days ago" +%Y-%m-%d` {{ container_name }} bundle exec rake cron:import --silent 


### PR DESCRIPTION
Whoopsie I didn't specify the env var correctly in the cron tab created in https://github.com/PLOS-Formulas/lagotto-formula/pull/24