### PR TITLE
fix-memcache-advert-port

### DIFF
--- a/lagotto/memcache.sls
+++ b/lagotto/memcache.sls
@@ -1,6 +1,6 @@
 {% from "consul/lib.sls" import consul_service_definition %}
 
-{{ consul_service_definition("alm-manager-memcache", port=5984, cluster="alm") }}
+{{ consul_service_definition("alm-manager-memcache", port=11211, cluster="alm") }}
 
 include:
   - memcache 


### PR DESCRIPTION

It was incorrectly using the couchDB port previously

memcache should be available on port 11211 per https://github.com/PLOS/molten/blob/0196ff6878ba87c747f24e8071386eb0f0eb4bdb/states/memcache/conf/etc/memcached.conf#L30