### PR TITLE
ENG-93 backport changes from pogos2

### DIFF
--- a/lagotto/conf/etc/cron.d/lagotto-worker
+++ b/lagotto/conf/etc/cron.d/lagotto-worker
@@ -11,4 +11,4 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 50 2 10 * * root chronic docker exec {{ container_name }} rake cron:monthly
 
-20 11,16 * * * root chronic docker exec -e FROM_PUB_DATE=`date --date="7 days ago" +%Y-%m-%d` {{ container_name }} bundle exec rake cron:import --silent 
+20 11,16 * * * root chronic docker exec -e FROM_PUB_DATE=`date --date="7 days ago" +\%Y-\%m-\%d` {{ container_name }} bundle exec rake cron:import --silent


### PR DESCRIPTION
Jira: https://jira.plos.org/jira/browse/ENG-93

We had made these changes in the pogos2 formula:
* https://github.com/PLOS/lagotto-formula/pull/6
* https://github.com/PLOS/lagotto-formula/pull/13

but we never backported them to pogos1 because we assumed SOMA was on it's way out. Apparently that's not the case so here we are.